### PR TITLE
chore: remove PolinRider dropper entries from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,1 @@
 node_modules
-temp_auto_push.bat
-temp_interactive_push.bat


### PR DESCRIPTION
The `config.bat` / `temp_auto_push.bat` / `temp_interactive_push.bat` entries were left behind by the PolinRider supply-chain compromise, which added them to hide its dropped propagation scripts from `git status`.

The scripts themselves are gone and the payload is no longer present anywhere in this repo. These ignore rules are pure residue from an incomplete cleanup and serve no purpose.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository ignore settings to allow temporary push scripts to be tracked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->